### PR TITLE
Added force_tsurf

### DIFF
--- a/src/Initialization.f90
+++ b/src/Initialization.f90
@@ -471,6 +471,7 @@ subroutine initSettings(inSettings, settings,inputParam,localParam)
    settings%coupling_minutes=inSettings%coupling_minutes
    settings%couplingEffectReduction=inSettings%couplingEffectReduction
    settings%outputStep=inSettings%outputStep
+   settings%force_tsurf=int2Logical(inSettings%force_tsurf)
  
 end subroutine initSettings
 

--- a/src/InputOutput.f90
+++ b/src/InputOutput.f90
@@ -113,7 +113,7 @@ Submodule (RoadSurf) ValueControl
       
          !call CalcTDew(REAL(atm%Tair, 8), atm%TDew, REAL(atm%Rhz, 8))
          !If in initialization phase, set surface temperature to observed value
-         if (i <= settings%InitLenI) Then
+         if (i <= settings%InitLenI .or. settings%force_tsurf) Then
             !if not in coupling phase
             if (modelInput%TsurfOBS(i) > -100.0) Then
       

--- a/src/InputSettings.f90.inc
+++ b/src/InputSettings.f90.inc
@@ -5,6 +5,8 @@ Type, Bind(C) :: InputSettings
       INTEGER(C_INT) :: SimLen                  !< Lenght of simulation
       INTEGER(C_INT) :: use_coupling            !< 1 if coupling is used
       INTEGER(C_INT) :: use_relaxation          !< 1 if relaxation is used
+      INTEGER(C_INT) :: force_tsurf              !< 1 if surface temperautre is forced
+                                                !< to given value full simulation
       REAL(C_DOUBLE) :: DTSecs                  !< time step in seconds
       REAL(C_DOUBLE) :: tsurfOutputDepth        !< depth to interpolate surface temperature (m)
       INTEGER(C_INT) :: NLayers                 !< Number of ground layers

--- a/src/ModelSettings.f90.inc
+++ b/src/ModelSettings.f90.inc
@@ -7,7 +7,8 @@ type ModelSettings
       integer:: SimLen                      !< Lenght of simulation
       logical :: use_coupling               !< coupling is used
       logical :: use_relaxation             !< true if relaxation is used
-                                                
+      logical :: force_tsurf                 !< true if tsurf forced to given
+                                            !< value for full simulation                                                
       integer:: NLayers                     !< number of ground layers
       real(8):: DTSecs                        !< time step in seconds
       real(8) :: tsurfOutputDepth              !< depth to interpolate output surface temperature


### PR DESCRIPTION
Added option to force the simulated surface temperature to the given value for the full simulation. Related to the XGBoost correction, this enables a second model run where surface temperature is forced to the corrected value to get other output variables in sync. 